### PR TITLE
fix: Include `index.scss` in build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.2.1](https://github.com/sparkbox/safe-focus/compare/v1.2.0...v1.2.1) (2020-02-19)
+
+
+### Bug Fixes
+
+* :bug: Include `index.scss` in build ([34f4734](https://github.com/sparkbox/safe-focus/commit/34f4734ff530d8b54ded3c2d81151a82fa7e3c3f))
+
 ## 1.2.0 (2020-02-19)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@sparkbox/safe-focus",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "index.scss"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sparkbox/safe-focus",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A utility file to add a custom outline style for all selectable components.",
   "main": "dist/safe-focus.cjs.js",
   "module": "dist/safe-focus.esm.js",


### PR DESCRIPTION
The `index.scss` file is required in the package, so we need to include that in the files.