### PR TITLE
fix: correct class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
 # Safe focus
+
 [![CircleCI](https://circleci.com/gh/sparkbox/safe-focus/tree/master.svg?style=svg)](https://circleci.com/gh/sparkbox/safe-focus/tree/master)
 
 Safe Focus is a utility file to add a custom outline style for all selectable components.
 
 ## Installation
+
 Run `npm i @sparkbox/safe-focus -P` in your local project.
 
 ## Usage
 
 ### JavaScript
+
 Require the package in your project and init the `safeFocusInit` import.
+
 ```
 import { safeFocusInit } from '@sparkbox/safe-focus';
 
@@ -17,7 +21,9 @@ safeFocusInit();
 ```
 
 ### Sass
+
 To use the `safe-focus` mixin, start by exposing `node_modules` to Sass in `package.json`.
+
 ```
 "sass": {
     "includePaths": ["./node_modules"]
@@ -25,11 +31,13 @@ To use the `safe-focus` mixin, start by exposing `node_modules` to Sass in `pack
 ```
 
 Next, import the package into your project's mixin file.
+
 ```
 @import '~@sparkbox/safe-focus/index';
 ```
 
 Encapsulate your styles with the `safe-focus` mixin:
+
 ```
 .my-button {
   outline: 1px solid #00b2e2;
@@ -40,8 +48,9 @@ Encapsulate your styles with the `safe-focus` mixin:
 ```
 
 This will result in the following transpiled CSS:
+
 ```
-my.button {
+.my-button {
   outline: 1px solid #00b2e2;
 }
 


### PR DESCRIPTION
Change docs to show the correct class name in the transpiled CSS code example.