### PR TITLE
chore: Check commit messages as GitHub action

### DIFF
--- a/.github/workflows/check-commit-messages.yml
+++ b/.github/workflows/check-commit-messages.yml
@@ -1,0 +1,27 @@
+name: 'Check Commit Message'
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+  push:
+    branches:
+      - master
+
+jobs:
+  check-commit-message:
+    name: Check Commit Message
+    runs-on: ubuntu-latest
+    steps:
+      - name: Commit begins with supported commit type
+        uses: gsactions/commit-message-checker@v1
+        with:
+          pattern: '^(feat|fix|docs|style|refactor|test|chore).+'
+          error: 'Commit messages must begin with a valid commit type. See "Commit Style" under CONTRIBUTING.md for more details.'
+          excludeDescription: 'true'
+          excludeTitle: 'true'
+          checkAllCommitMessages: 'true'
+          accessToken: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,22 @@
 - Assign a [sparkboxer][contributors] to review your PR
 
 ## Commit Style
-We use [Conventional Commits] and [Standard Version] to automate versioning of this package. Commit messages must be prefixed with a valid commit type.
+We use [Conventional Commits] and [Standard Version] to automate versioning of this package. Commit messages must be prefixed with a valid commit type and the commit type cannot be prefixed with any additional text.
 
-Example:
+Supported commit types include `feat`, `fix`, `docs`, `style`, `refactor`, and `test`.
+
+Valid example:
 ```sh
 feat: add new linting rule for ...
+```
+
+Invalid examples:
+```sh
+feature: add new linting rule for ...
+```
+
+```sh
+:sparkles: feat: add new linting rule for ...
 ```
 
 ℹ️ See the [Conventional Commits] page for further details on available commit types and how to handle breaking changes.


### PR DESCRIPTION
⚠️  This PR contains validation commits that should not be merged into `master`. Before merging, please let me know so I can drop them.

### Description

This PR adds support for enforcing the correct commit message format in the GitHub action. Since releases for this package are cut using standard version, the commit message must begin with a supported subject.

## Validation Steps
1. Visit the [GitHub action](https://github.com/sparkbox/safe-focus/actions/runs/309069284) that was run after including only valid commit types.
- [x] Confirm the action is passing. This demonstrates that accepted commit types pass CI.
2. Visit the [GitHub action](https://github.com/sparkbox/safe-focus/actions/runs/309074496) that was run after including an invalid commit types.
- [x] Confirm the action is failing. This demonstrates that unaccepted commit types fail CI.
3. Visit the [GitHub action](https://github.com/sparkbox/safe-focus/actions/runs/309075037) that was run after including an additional valid commit type.
- [x] Confirm the action is failing. This demonstrates that even with the last commit type being valid, the action still fails if the PR contains commit types that are invalid.

