### PR TITLE
Chore: Preview Bumped Version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,8 @@ When making a change that requires a new version to be published, you'll want to
 $ npm run release
 ```
 
-This will:
+After running this command, you'll get a preview of what the next tagged version would be. If you proceed, the release script will:
+
 - Use all commit messages since the latest version tag to determine the correct new version
 - Increment the version in package.json and package-lock.json
 - Create a tagged commit with the new version
@@ -46,6 +47,27 @@ This will:
 After your branch is merged, CI will take care of publishing to the npm registry.
 
 ℹ️ See the [Standard Version][standard cli] documentation for details on how to control versioning behavior.
+
+### Specifying a release type
+Sometimes, you'll want manual control over the next version of the package. In these case, you can use the special `--major`, `--minor`, and `--patch` flags.
+
+Major Release
+
+```sh
+npm run release -- --major
+```
+
+Minor Release
+
+```sh
+npm run release -- --minor
+```
+
+Patch Release
+
+```sh
+npm run release -- --patch
+```
 
 [pr]: https://github.com/sparkbox/safe-focus/compare
 [contributors]: https://github.com/sparkbox/safe-focus/graphs/contributors

--- a/package-lock.json
+++ b/package-lock.json
@@ -6613,6 +6613,12 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
+    },
     "is-path-inside": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
@@ -8599,6 +8605,392 @@
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
       "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=",
       "dev": true
+    },
+    "next-standard-version": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/next-standard-version/-/next-standard-version-2.1.3.tgz",
+      "integrity": "sha512-GtsXSlALcteq65eMRhE9vm/hQWE2tXDobLBVmfBzxn8Bj327gHn5F4aDs0gYHiqS6fu1/WhIRNEsxe+FBiPBEQ==",
+      "dev": true,
+      "requires": {
+        "semver": "7.3.2",
+        "standard-version": "8.0.0",
+        "strip-ansi": "6.0.0",
+        "yargs": "15.3.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "camelcase-keys": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+          "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0",
+            "map-obj": "^2.0.0",
+            "quick-lru": "^1.0.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "compare-func": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.4.tgz",
+          "integrity": "sha512-sq2sWtrqKPkEXAC8tEJA1+BqAH9GbFkGBtUOqrUX57VSfwp8xyktctk+uLoRy5eccTdxzDcVIztlYDpKs3Jv1Q==",
+          "dev": true,
+          "requires": {
+            "array-ify": "^1.0.0",
+            "dot-prop": "^3.0.0"
+          }
+        },
+        "conventional-changelog": {
+          "version": "3.1.18",
+          "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-3.1.18.tgz",
+          "integrity": "sha512-aN6a3rjgV8qwAJj3sC/Lme2kvswWO7fFSGQc32gREcwIOsaiqBaO6f2p0NomFaPDnTqZ+mMZFLL3hlzvEnZ0mQ==",
+          "dev": true,
+          "requires": {
+            "conventional-changelog-angular": "^5.0.6",
+            "conventional-changelog-atom": "^2.0.3",
+            "conventional-changelog-codemirror": "^2.0.3",
+            "conventional-changelog-conventionalcommits": "^4.2.3",
+            "conventional-changelog-core": "^4.1.4",
+            "conventional-changelog-ember": "^2.0.4",
+            "conventional-changelog-eslint": "^3.0.4",
+            "conventional-changelog-express": "^2.0.1",
+            "conventional-changelog-jquery": "^3.0.6",
+            "conventional-changelog-jshint": "^2.0.3",
+            "conventional-changelog-preset-loader": "^2.3.0"
+          }
+        },
+        "conventional-changelog-conventionalcommits": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.2.3.tgz",
+          "integrity": "sha512-atGa+R4vvEhb8N/8v3IoW59gCBJeeFiX6uIbPu876ENAmkMwsenyn0R21kdDHJFLQdy6zW4J6b4xN8KI3b9oww==",
+          "dev": true,
+          "requires": {
+            "compare-func": "^1.3.1",
+            "lodash": "^4.17.15",
+            "q": "^1.5.1"
+          }
+        },
+        "conventional-recommended-bump": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-6.0.5.tgz",
+          "integrity": "sha512-srkferrB4kACPEbKYltZwX1CQZAEqbQkabKN444mavLRVMetzwJFJf23/+pwvtMsWbd+cc4HaleV1nHke0f8Rw==",
+          "dev": true,
+          "requires": {
+            "concat-stream": "^2.0.0",
+            "conventional-changelog-preset-loader": "^2.3.0",
+            "conventional-commits-filter": "^2.0.2",
+            "conventional-commits-parser": "^3.0.8",
+            "git-raw-commits": "2.0.0",
+            "git-semver-tags": "^3.0.1",
+            "meow": "^5.0.0",
+            "q": "^1.5.1"
+          }
+        },
+        "dot-prop": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
+          "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+          "dev": true,
+          "requires": {
+            "is-obj": "^1.0.0"
+          }
+        },
+        "git-semver-tags": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-3.0.1.tgz",
+          "integrity": "sha512-Hzd1MOHXouITfCasrpVJbRDg9uvW7LfABk3GQmXYZByerBDrfrEMP9HXpNT7RxAbieiocP6u+xq20DkvjwxnCA==",
+          "dev": true,
+          "requires": {
+            "meow": "^5.0.0",
+            "semver": "^6.0.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+              "dev": true
+            }
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "map-obj": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+          "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+          "dev": true
+        },
+        "meow": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
+          "integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
+          "dev": true,
+          "requires": {
+            "camelcase-keys": "^4.0.0",
+            "decamelize-keys": "^1.0.0",
+            "loud-rejection": "^1.0.0",
+            "minimist-options": "^3.0.1",
+            "normalize-package-data": "^2.3.4",
+            "read-pkg-up": "^3.0.0",
+            "redent": "^2.0.0",
+            "trim-newlines": "^2.0.0",
+            "yargs-parser": "^10.0.0"
+          }
+        },
+        "minimist-options": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
+          "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+          "dev": true,
+          "requires": {
+            "arrify": "^1.0.1",
+            "is-plain-obj": "^1.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "quick-lru": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+          "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+              "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+              "dev": true,
+              "requires": {
+                "locate-path": "^2.0.0"
+              }
+            }
+          }
+        },
+        "redent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+          "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+          "dev": true,
+          "requires": {
+            "indent-string": "^3.0.0",
+            "strip-indent": "^2.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        },
+        "standard-version": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-8.0.0.tgz",
+          "integrity": "sha512-cS/U9yhYPHfyokFce6e/H3U8MaKwZKSGzH25J776sChrae/doDQjsl3vCQ0hW1MSzdrUTb7pir4ApjnbDt/TAg==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.4.2",
+            "conventional-changelog": "3.1.18",
+            "conventional-changelog-config-spec": "2.1.0",
+            "conventional-changelog-conventionalcommits": "4.2.3",
+            "conventional-recommended-bump": "6.0.5",
+            "detect-indent": "6.0.0",
+            "detect-newline": "3.1.0",
+            "dotgitignore": "2.1.0",
+            "figures": "3.1.0",
+            "find-up": "4.1.0",
+            "fs-access": "1.0.1",
+            "git-semver-tags": "3.0.1",
+            "semver": "7.1.1",
+            "stringify-package": "1.0.1",
+            "yargs": "15.3.1"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "7.1.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.1.tgz",
+              "integrity": "sha512-WfuG+fl6eh3eZ2qAf6goB7nhiCd7NPXhmyFxigB/TOkQyeLP8w8GsVehvtGNtnNmyboz4TgeK40B1Kbql/8c5A==",
+              "dev": true
+            }
+          }
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "trim-newlines": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+          "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
+        }
+      }
     },
     "nice-try": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint:style": "stylelint **.scss --formatter verbose",
     "lint:js": "eslint --ignore-path .gitignore .",
     "prepublishOnly": "npm run build",
-    "release": "standard-version && git push --follow-tags origin head",
+    "release": "./script/release.sh",
     "test": "jest"
   },
   "repository": {
@@ -43,6 +43,7 @@
     "eslint-plugin-import": "^2.20.2",
     "jest": "^25.5.2",
     "jest-environment-jsdom-sixteen": "^1.0.3",
+    "next-standard-version": "^2.1.3",
     "rollup": "^1.32.1",
     "standard-version": "^9.0.0",
     "stylelint": "^13.3.3"

--- a/script/release.sh
+++ b/script/release.sh
@@ -1,0 +1,40 @@
+# The name of your prodution branch. This script will not allow users to release a new version
+# if they're not on the correct branch
+PRODUCTION_BRANCH="master"
+
+CURRENT_BRANCH=$(git branch | sed -n -e 's/^\* \(.*\)/\1/p')
+if [[ $CURRENT_BRANCH != $PRODUCTION_BRANCH ]]
+  then
+  echo "\033[1;31mCannot release while on branch '$CURRENT_BRANCH' - please switch to '$PRODUCTION_BRANCH'.\033\n[0m"
+  exit 1
+fi
+
+RELEASE_OPTION=$1
+case $RELEASE_OPTION in
+  --major)
+    RELEASE_TYPE='major'
+    ;;
+  --minor)
+    RELEASE_TYPE='minor'
+    ;;
+  --patch)
+    RELEASE_TYPE='patch'
+    ;;
+esac
+
+# If we've specified a type of release, we need to include the `releaseAs` argument
+SPECIFIED_RELEASE_TYPE_ARG=$([ $RELEASE_TYPE ] && echo "--releaseAs $RELEASE_TYPE");
+CURRENT_PACKAGE_VERSION=$(node -e "process.stdout.write(require('./package.json').version)")
+NEXT_VERSION=$(npx next-standard-version ${SPECIFIED_RELEASE_TYPE_ARG})
+echo "\033[33mBump plugin from ${CURRENT_PACKAGE_VERSION} to ${NEXT_VERSION}?\033[0m\n"
+echo "\033[33mPress \"y\" to proceed with this release or press any other key to abort.\033[0m\n"
+
+read -p "" -n 1 -s
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+  npx standard-version -a $([ $RELEASE_TYPE ] && echo "--release-as $RELEASE_TYPE")
+  git push --follow-tags
+  echo "\033[1;32mPackage succesfully updated to ${NEXT_VERSION} and pushed to the remote.\033[0m\n"
+else
+  echo "\033[1;31mRelease was aborted.\033[0m\n"
+fi


### PR DESCRIPTION

# Summary
This PR adds support for allowing users to preview what the next version of a published package would be and gives them the opportunity to abort the release, if necessary.

# Validation
### 1. Only running on `master`
1. Pull down this branch.
2. Run `npm run release`
- [x] Confirm the script refuses to release on a non-production branch.

### 2. Aborting release
1. Apply this [patch](https://github.com/sparkbox/safe-focus/files/5467491/patch_chore--preview-new-version.zip)
. This patch will allow you to run the script on a non-production branch and will prevent any releases from being pushed to the remote.
1. Run `npm run release`.
- [x] Confirm the script prompts you to approve releasing a patched version of the package.
1. Press a key either than "y".
- [x] Confirm the script exits.

### 3. Default releases
1. Run `npm run release`.
- [x] Confirm the script prompts you to approve releasing a patched version of the package.
1. Press "y".
- [x] Confirm the script says it's bumping the package as a patch.

### 4. Patch releases
1. Run `npm run release -- --patch`.
- [x] Confirm the script prompts you to approve releasing a patched version of the package.
1. Press "y".
- [x] Confirm the script says it's bumping the package as a patch.

### 5. Minor releases
1. Run `npm run release -- --minor`.
- [x] Confirm the script prompts you to approve releasing a minor bumped version of the package.
1. Press "y".
- [x] Confirm the script says it's bumping the package as a minor version.

### 6. Major releases
1. Run `npm run release -- --major`.
- [x] Confirm the script prompts you to approve releasing a major bumped version of the package.
1. Press "y".
- [x] Confirm the script says it's bumping the package as a major version.
